### PR TITLE
More efficient 1D two body integrals

### DIFF
--- a/quantum_systems/quantum_dots/one_dim/one_dim_qd.py
+++ b/quantum_systems/quantum_dots/one_dim/one_dim_qd.py
@@ -17,7 +17,7 @@ from quantum_systems.quantum_dots.one_dim.one_dim_potentials import (
 
 
 @numba.njit
-def trapz_prep(vec, dx):
+def _trapz_prep(vec, dx):
     # The trapezoidal method applied to a vector can be implemented as multiplying it by dx, halving the ends, and taking the sum.
     # Since we are applying the trapezoidal method to a product of 3 vectors,
     # we can first perform the first two steps on this vector, which is reused, to greatly speed up the calculation.

--- a/quantum_systems/quantum_dots/one_dim/one_dim_qd.py
+++ b/quantum_systems/quantum_dots/one_dim/one_dim_qd.py
@@ -17,15 +17,14 @@ from quantum_systems.quantum_dots.one_dim.one_dim_potentials import (
 
 
 @numba.njit
-def _trapz(f, x):
-    n = len(x)
-    delta_x = x[1] - x[0]
-    val = 0
-
-    for i in range(1, n):
-        val += f[i - 1] + f[i]
-
-    return 0.5 * val * delta_x
+def trapz_prep(vec, dx):
+    # The trapezoidal method applied to a vector can be implemented as multiplying it by dx, halving the ends, and taking the sum.
+    # Since we are applying the trapezoidal method to a product of 3 vectors,
+    # we can first perform the first two steps on this vector, which is reused, to greatly speed up the calculation.
+    prepped_vec = vec * dx
+    prepped_vec[0] *= 0.5
+    prepped_vec[-1] *= 0.5
+    return prepped_vec
 
 
 @numba.njit
@@ -36,15 +35,17 @@ def _shielded_coulomb(x_1, x_2, alpha, a):
 @numba.njit
 def _compute_inner_integral(spf, l, num_grid_points, grid, alpha, a):
     inner_integral = np.zeros((l, l, num_grid_points), dtype=np.complex128)
+    dx = grid[1] - grid[0]
 
     for i in range(num_grid_points):
         coulomb = _shielded_coulomb(grid[i], grid, alpha, a)
+        trapz_prepped_coulomb = _trapz_prep(coulomb, dx)
         for q in range(l):
+            trapz_prod = np.conjugate(spf[q]) * trapz_prepped_coulomb
             for s in range(l):
-                inner_integral[q, s, i] = _trapz(
-                    np.conjugate(spf[q]) * coulomb * spf[s],
-                    grid,
-                )
+                inner_integral[q, s, i] = np.dot(
+                    trapz_prod, spf[s]
+                )  # _trapz(np.conjugate(spf[q]) * coulomb * spf[s], grid)
 
     return inner_integral
 
@@ -52,14 +53,17 @@ def _compute_inner_integral(spf, l, num_grid_points, grid, alpha, a):
 @numba.njit
 def _compute_orbital_integrals(spf, l, inner_integral, grid):
     u = np.zeros((l, l, l, l), dtype=np.complex128)
-    for p in range(l):
-        for q in range(l):
-            for r in range(l):
-                for s in range(l):
-                    u[p, q, r, s] = _trapz(
-                        np.conjugate(spf[p]) * inner_integral[q, s] * spf[r],
-                        grid,
-                    )
+    dx = grid[1] - grid[0]
+
+    for q in range(l):
+        for s in range(l):
+            trapz_prepped_inner = _trapz_prep(inner_integral[q, s], dx)
+            for p in range(l):
+                trapz_prod = np.conjugate(spf[p]) * trapz_prepped_inner
+                for r in range(l):
+                    u[p, q, r, s] = np.dot(
+                        trapz_prod, spf[r].astype(np.complex128)
+                    )  # _trapz(np.conjugate(spf[p]) * inner_integral[q, s] * spf[r], grid)
 
     return u
 


### PR DESCRIPTION
The trapezoidal method applied to a vector can be implemented as multiplying it by dx, halving the ends, and taking the sum of the elements.

Since we are applying the trapezoidal method to a product of 3 vectors, we can perform the first two steps on the vector which is available outside the double loop. We can then perform the first vector product inside the first loop, and only perform a dot product inside the double loop.

This is much faster than computing two vector products and applying the trapezoidal method inside the double loop.